### PR TITLE
Update README

### DIFF
--- a/features/0312-crypto-service/README.md
+++ b/features/0312-crypto-service/README.md
@@ -1,6 +1,6 @@
 # Aries RFC 0312: Crypto service Protocol 1.0
 
-- Authors: Robert Mitwicki
+- Authors: Robert Mitwicki, Wolfgang Lamot
 - Status: [PROPOSED](/README.md#proposed)
 - Since: 2019-11-20 (date you submit your PR)
 - Status Note: RFC under development
@@ -10,41 +10,41 @@
 
 ## Summary
 
-Within decentralized data economy with user-centric approach user is the one who should control data flows and all interaction even on 3rd parties platforms. To achieve that we starting talking about access instead of ownership of the data. Within the space we can identify some services which are dealing with your data but they don't necessarily need to be able to see the data. In this category we have services like archive, data vaults, data transportation (IM, Email, Sent file), etc. To be able to better support privacy in such cases this document proposes a protocol which uses underlying security mechanisms within agents like `Lox` to provide API for cryptographic operation like encryption, decryption, signature, verification, proxy re-encryption to let those services to provide additional security layer on their platform within connection to SSI wallet agents.
+Within decentralized data economy with user-centric approach the user is the one who should control data flows and all interaction even on 3rd parties platforms. To achieve that we start to talk about access instead of ownership of the data. Within the space we can identify some services which are dealing with the users data but they don't necessarily need to be able to see the data. In this category we have services like archive, data vaults, data transportation (IM, Email, Sent file), etc. To be able to better support privacy in such cases this document proposes a protocol which uses underlying security mechanisms within agents like `Lox` to provide an API for cryptographic operations like asymetric encryption/decryption, signature/verification, delegation (proxy re-encryption) to let those services provide an additional security layer on their platform within connection to SSI wallet agents.
 
 ## Motivation
 
-Identity management and key management are complex topics with which even big players having problems. To help companies and their products build secure and privacy preserving services with SSI they need a simple mechanism to get access to the cryptographic operation within components of the wallets.
+Identity management and key management are complex topics with which even big players have problems. To help companies and their products build secure and privacy preserving services with SSI they need a simple mechanism to get access to the cryptographic operations within components of the wallets.
 
-Many services provides solutions like secure storage, encryption communication, secure data transportation and to achieve that they are using secure keys to provide cryptography for their use cases. The problem is that in many cases those keys are generated within their services which reduce the trust and increase the risk of leaking the key.
+Many services provide solutions like secure storage, encrypted communication, secure data transportation and to achieve that they are using secure keys to provide cryptography for their use cases. The problem is that in many cases those keys are generated within their services which reduce the trust and increase the risk of leaking the key.
 
-The ideal solution is that the keys are generated within user agent and never leaves that place.
+The ideal solution is that the keys are generated within user agent and that the private (secret) key never leaves that place.
 
-Providing general crypto API to the user wallet allows to support generic use cases where cryptography layer is required, for example :
+Providing general crypto API to the user wallet allows to support generic use cases where a cryptographic layer is required in the service, for example:
 
 - encrypted data in data vaults
 - encrypted messages within 3rd party service
 - additional security layers outside of Agent ecosystem, data transportation, messaging over non-DIDComm protocols.
 - backup/restore systems
 
-Desired outcome would be to have Agent which is able to expose crypto API to external services.
+Desired outcome would be to have an Agent which is able to expose the crypto API to external services.
 
 ## Tutorial
 
 ### Name and Version
 
-This defines the `crypto-service` protocol. version 0.1, as identified by the following PIURI:
+This defines the `crypto-service` protocol. version 1.0, as identified by the following PIURI:
 
     TODO: Add PIURI when ready
 
 ### Roles
 
-The minimum amount of roles involved in the `crypto-service` protocol are: `sender` and `receiver`. The `sender` request certian operation from the `receiver` and `receiver` provides result in a form of payload or an error.
-Protocl could incolde more roles which could be involved in process of proxy re-encryption, delegation etc.
+The minimum amount of roles involved in the `crypto-service` protocol are: a `sender` and a `receiver`. The `sender` requests a specific cryptographic operation from the `receiver` and the `receiver` provides the result in a form of a payload or an error.
+The protocol could include more roles (e.g. a `proxy`) which could be involved in processes like delegation (proxy re-encryption), etc.
 
 ### Constraints
 
-Each message which is sent to the agent required up front established relationship between sender and receiver in a form of authorization. Means that the sender is allow to use only this specific key which is meant for him. There should not be the case where the sender is able to trigger any operation with keys which where never used within his service.
+Each message which is send to the agent requires an up front established relationship between sender and receiver in the form of an authorization. This means that the sender is allowed to use only the specific key which is meant for him. There should not be the case that the sender is able to trigger any operation with keys which where never used within his service.
 
 ## Reference
 
@@ -52,31 +52,32 @@ Each message which is sent to the agent required up front established relationsh
 
 Specific use case example:
 
-Platform providing secure document transportation between parties and archiving functionality.
+A platform providing secure document transportation between parties and archiving functionality.
 
 Actors:
 
-- `Sender`: User sending document
-- `Receiver`: User receiving document
-- `DocuArch` - Platform providing secure document transportation and archiving.
-- `DocuArchApp` - client side application allowing to display documents
+- `Sender`: user sending document
+- `Receiver`: user receiving document
+- `DocuArch`: platform providing secure document transportation and archiving
+- `DocuArchApp`: client side application allowing to up-/download and display documents
 
 Here is how it could work:
 
-- `Receiver` register to the services with his DID identity
+- `Receiver` register to the services with his DID identity (via `DocuArchApp`)
 - `Receiver` share his DID with the `Sender`
-- `Sender` knowing DID of the `Receiver` encrypt the document with `Receiver` public key and sends document on the platform.
-- `DocuArch` securely transport that document to the `Receiver` at the same time archiving it for the `Sender` and `Receiver`.
+- `Sender` knowing DID of the `Receiver` encrypts the document with `Receiver` public key and sends document on the platform
+- `DocuArch` securely transports that document to the `Receiver` at the same time archiving it for the `Sender` and `Receiver`
 - `Receiver` is informed by the `DocuArchApp` that there is a new document to view.
+- `Receiver` securely logs into `DocuArchApp` with his DID identity
 - `Receiver` opens encrypted payload within `DocuArchApp`
-- `DocuArchApp` send request to the user Agent to decrypt the message for the `Receiver`
-- Agent decrypt the message and sent back decrypted payload
-- `DocuArch` displays decrypted payload within local app.
+- `DocuArchApp` sends request to the user Agent to decrypt the message for the `Receiver`
+- Agent decrypts the message and sends back the decrypted payload
+- `DocuArchApp` displays the decrypted payload within local app
 
-In this scenario `DocuArch` has no way to learn about what is in the payload which is sent between `Sender` and `Receiver` as the only person who is in possession of the private key is able to decrypt the payload is `Receiver`
-Decrypted payload never leaves `Receiver` client app.
+In this scenario `DocuArch` has no way to learn about what is in the payload which is sent between `Sender` and `Receiver` as only the person who is in possession of the private key is able to decrypt the payload - which is the `Receiver`.
+Therfore the decrypted payload is only available on the `Receivers` client side app which is in communication with the Agent on behalf of the users DID identity.
 
-Such feature within Agent allow companies to build faster and more secure systems as the identity management and key management part comes from Agents and they just interact with it via API.
+Such features within the Agent allow companies to build faster and more secure systems as the identity management and key management part comes from Agents and they just interact with it via API.
 
 ### Messages
 
@@ -91,8 +92,8 @@ Protocol: did:sov:1234;spec/crypto-service/1.0
     {
         "@id": "1234567889",
         "@type": "did:sov:1234;spec/crypto-service/1.0/encrypt",
-        "payload": "Text to be encrypted"
-        "key_id": "did:example:123456789abcdefghi#keys-1
+        "payload": "Text to be encrypted",
+        "key_id": "did:example:123456789abcdefghi#keys-1"
 
     }
 ```
@@ -106,8 +107,8 @@ Protocol: did:sov:1234;spec/crypto-service/1.0
     {
         "@id": "1234567889",
         "@type": "did:sov:1234;spec/crypto-service/1.0/decrypt",
-        "encryptedPayload": "ASDD@J(!@DJ!DASD!@F"
-        "key_id": "did:example:123456789abcdefghi#keys-1
+        "encryptedPayload": "ASDD@J(!@DJ!DASD!@F",
+        "key_id": "did:example:123456789abcdefghi#keys-1"
 
     }
 ```
@@ -121,8 +122,8 @@ Protocol: did:sov:1234;spec/crypto-service/1.0
     {
         "@id": "1234567889",
         "@type": "did:sov:1234;spec/crypto-service/1.0/sign",
-        "payload": "I say so!"
-        "key_id": "did:example:123456789abcdefghi#keys-1
+        "payload": "I say so!",
+        "key_id": "did:example:123456789abcdefghi#keys-1"
 
     }
 ```
@@ -136,19 +137,26 @@ Protocol: did:sov:1234;spec/crypto-service/1.0
     {
         "@id": "1234567889",
         "@type": "did:sov:1234;spec/crypto-service/1.0/verify",
-        "signature": "12312d8u182d812d9182d91827d179"
-        "key_id": "did:example:123456789abcdefghi#keys-1
+        "signature": "12312d8u182d812d9182d91827d179",
+        "key_id": "did:example:123456789abcdefghi#keys-1"
 
     }
 ```
 
-**delegation**
+**delegate**
 
-TODO
+- delegate - DID of the delegate identity for which the proxy re-encryption token shall be generated
+- key_id - reference to the specific did key which was used to establish connection with the service.
 
-**transitivity**
+```
+    {
+        "@id": "1234567889",
+        "@type": "did:sov:1234;spec/crypto-service/1.0/delegate",
+        "delegate": "did:example:ihgfedcba987654321",
+        "key_id": "did:example:123456789abcdefghi#keys-1"
 
-TODO
+    }
+```
 
 ### Message Catalog
 
@@ -165,9 +173,9 @@ TODO
 
 ## Rationale and alternatives
 
-We can not expect that each services will switch directly to the DIDComm and other features of the agents. Not all features are even desier to have within agent. But if the Agent can exposer base API for identity management and crypto operation this would allow others to build on top of it much more richer applications and platforms.
+We can not expect that each services will switch directly to the DIDComm and other features of the agents. Not all features are even desier to have within agent. But if the Agent can exposer base API for identity management and crypto operations this would allow others to build on top of it much more richer ans secure applications and platforms.
 
-I am not aware of any alternatives atm. Anyone?
+We are not aware of any alternatives atm. Anyone?
 
 ## Prior art
 
@@ -175,10 +183,10 @@ Similar approach is taken within HSM world where API is expose to the outside wo
 
 ## Unresolved questions
 
-- How to check authorization that this service is allow to use those set of the keys?
+- How to check authorization that a given service is allowed to use a specific set of the keys?
 - How to protect user against malicious requests?
-- What other operation should be supported?
-- What are the limitation in the context of payload?
+- What other operations should be supported?
+- What are the limitations in the context of payload?
 
 ## Implementations
 


### PR DESCRIPTION
Typos and Message for Delegation. 
Note: "Transitivity" or "Multi-hop" in the context of proxy re-encryption is a cascaded use of "Delegaten" (A->B, B->C, ...) therefor one wallet/agent can't support this alone. Each new delegation token needs to be separately calculated from each wallet/agent in possession of the next required private key per hop.